### PR TITLE
AuthTypes.Login and AuthTypes.None fixes, added auth type selection for client

### DIFF
--- a/socks5/socks5/Socks/SocksClient.cs
+++ b/socks5/socks5/Socks/SocksClient.cs
@@ -33,7 +33,7 @@ namespace socks5.Socks
             SocksEncryption w = null;
             List<object> lhandlers = PluginLoader.LoadPlugin(typeof(LoginHandler));
             //check out different auth types, none will have no authentication, the rest do.
-            if (lhandlers.Count > 0 && authtypes.Contains(AuthTypes.SocksBoth) || authtypes.Contains(AuthTypes.SocksEncrypt) || authtypes.Contains(AuthTypes.SocksCompress) || authtypes.Contains(AuthTypes.Login))
+            if (lhandlers.Count > 0 && (authtypes.Contains(AuthTypes.SocksBoth) || authtypes.Contains(AuthTypes.SocksEncrypt) || authtypes.Contains(AuthTypes.SocksCompress) || authtypes.Contains(AuthTypes.Login)))
             {
                 //this is the preferred method.
                 w = Socks5.RequestSpecialMode(authtypes, Client);

--- a/socks5/socks5/Socks5Client/Socks.cs
+++ b/socks5/socks5/Socks5Client/Socks.cs
@@ -86,9 +86,9 @@ namespace socks5.Socks5Client
                 p.Client.Disconnect();
                 return false;
             }
+            p.enc = new Encryption.SocksEncryption();
             if (auth != AuthTypes.None)
             {
-                p.enc = new Encryption.SocksEncryption();
                 switch (auth)
                 {
                     case AuthTypes.Login:

--- a/socks5/socks5/Socks5Client/Socks5Client.cs
+++ b/socks5/socks5/Socks5Client/Socks5Client.cs
@@ -28,12 +28,20 @@ namespace socks5.Socks5Client
 
         public Encryption.SocksEncryption enc;
 
+        public IList<AuthTypes> UseAuthTypes { get; set; }
+
         public event EventHandler<Socks5ClientArgs> OnConnected = delegate { };
         public event EventHandler<Socks5ClientDataArgs> OnDataReceived = delegate { };
         public event EventHandler<Socks5ClientDataArgs> OnDataSent = delegate { };
         public event EventHandler<Socks5ClientArgs> OnDisconnected = delegate { };
 
+        private Socks5Client()
+        {
+            UseAuthTypes = new List<AuthTypes>(new[] { AuthTypes.None, AuthTypes.Login, AuthTypes.SocksEncrypt });
+        }
+
         public Socks5Client(string ipOrDomain, int port, string dest, int destport, string username = null, string password = null)
+            : this()
         {
             //Parse IP?
             if (!IPAddress.TryParse(ipOrDomain, out ipAddress))
@@ -56,6 +64,7 @@ namespace socks5.Socks5Client
             DoSocks(ipAddress, port, dest, destport, username, password);
         }
         public Socks5Client(IPAddress ip, int port, string dest, int destport, string username = null, string password = null)
+            : this()
         {
             DoSocks(ip, port, dest, destport, username, password);
         }


### PR DESCRIPTION
The second commit (Socks5Client NullReferenceException) - the exception occured in `Socks.SendRequest` at the line:
`cli.Send(enc.ProcessOutputData(p, 0, p.Length));`
`enc` was `null`.