### PR TITLE
fix net::ERR_CONNECTION_RESET 200 (Ok) problem in chrome

### DIFF
--- a/socks5/socks5/TCP/Client.cs
+++ b/socks5/socks5/TCP/Client.cs
@@ -129,6 +129,7 @@ namespace socks5.TCP
                     if (this.Sock != null && this.Sock.Connected)
                     {
                         onClientDisconnected(this, new ClientEventArgs(this));
+                        this.Sock.Shutdown(SocketShutdown.Both);
                         this.Sock.Close();
                         //this.Sock = null;
                         return;


### PR DESCRIPTION
Missing Sock.Shutdown() and not all data is sent and received to the client.
This problem happens when remote server using "Connection: close", content won't send to client after HTTP header at all, because remote server close the connection too quickly.
Takes me a lot of time to find out the wrong code :P